### PR TITLE
Check that the tenant id is in the list

### DIFF
--- a/keystone_voms/core.py
+++ b/keystone_voms/core.py
@@ -266,7 +266,7 @@ class VomsAuthNMiddleware(wsgi.Middleware):
         if CONF.voms.autocreate_users:
             tenants = self.identity_api.list_projects_for_user(user_ref["id"])
 
-            if tenant not in tenants:
+            if tenant['id'] not in tenants:
                 self._add_user_to_tenant(user_ref['id'], tenant['id'])
 
         return user_dn, tenant['name']

--- a/tests/test_middleware_voms_authn.py
+++ b/tests/test_middleware_voms_authn.py
@@ -237,6 +237,26 @@ class MiddlewareVomsAuthn(test.TestCase):
         user_out = req.environ['REMOTE_USER']
         self.assertEqual(user_out, user_dn)
 
+    def test_middleware_proxy_user_not_found_autocreate_once(self):
+        """Verify that user is autocreated only once"""
+        CONF.voms.autocreate_users = True
+        req = prepare_request(get_auth_body(tenant="BAR"),
+                              valid_cert,
+                              valid_cert_chain)
+
+        aux = keystone_voms.VomsAuthNMiddleware(None)
+        aux._no_verify = True
+        aux._process_request(req)
+        user_out = req.environ['REMOTE_USER']
+        self.assertEqual(user_out, user_dn)
+
+        req = prepare_request(get_auth_body(tenant="BAR"),
+                              valid_cert,
+                              valid_cert_chain)
+        aux._process_request(req)
+        user_out = req.environ['REMOTE_USER']
+        self.assertEqual(user_out, user_dn)
+
     def test_middleware_proxy_user_not_found_autocreate_unscoped(self):
         """Verify that user is autocreated with unscoped request"""
         CONF.voms.autocreate_users = True


### PR DESCRIPTION
The comparison was wrong, therefore the code was adding the user to the
tenant when it was already there. This raised an exception.Conflict. Also
added a unittest for this case.

Cherry picked from 029d2ff715f0efa4bf3ab29d8b40aae963e69065 and
55e5002212297d57632fd50d0526472dd0ed2cd9
