### PR TITLE
docs: fix building of documentation

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,0 +1,4 @@
+pbr>=1.6
+oslo.config>=2.3.0
+oslo.log>=1.8.0
+oslo.serialization>=1.4.0

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,9 @@ deps = coveralls
        {[testenv]deps}
 
 [testenv:docs]
+install_command = pip install -U --no-deps {opts} {packages}
+deps = -r{toxinidir}/doc-requirements.txt
+       -r{toxinidir}/test-requirements.txt
 commands = python setup.py build_sphinx
 
 [testenv:genconfig]


### PR DESCRIPTION
We do not need to install Keystone (in the requirements.txt file) to
generate the documentation.