### PR TITLE
Include PUSP support relying on gridsite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ virtualenv:
     system_site_packages: true
 
 install:
-    - pip install tox
+    - pip install --upgrade tox
     - pip install -r requirements.txt
     - pip install -r test-requirements.txt
     - pip install -e git+https://github.com/openstack/keystone@stable/mitaka#egg=keystone

--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -32,6 +32,7 @@ under the ``[voms]`` section::
     autocreate_users = False
     add_roles = False
     user_roles = _member_
+    enable_pusp = False
 
 * ``vomsdir_path``: Path storing the ``.lsc`` files.
 * ``ca_path``: Path where the CAs and CRLs are stored.
@@ -40,6 +41,8 @@ under the ``[voms]`` section::
 * ``autocreate_users``: Whether a user should be autocreated if it does not exist.
 * ``add_roles``: Whether roles should be added to users or not.
 * ``user_roles``: list of role names to add to the users (if ``add_roles`` is ``True``).
+* ``enable_pusp``: if enabled, when a user with a PUSP is detected, it will be
+  handled as independent user.
 
 Allowed VOs
 -----------

--- a/doc/source/requirements.rst
+++ b/doc/source/requirements.rst
@@ -164,6 +164,21 @@ With the above configuration, and assuming that the Keystone host is
 * ``https://keystone.example.org:35357/`` will be administration endpoint,
   thus the Keystone URL will be ``https://keystone.example.org:35357/v2.0``
 
+GridSite and Per-User-Sub-Proxy support
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Support for Per-User-Sub-Proxy so robot certificates with extra user
+information is mapped to individual users requires the `GridSite module
+<https://github.com/cesnet/gridsite>`_ v2.3.3 or later for Apache installed
+and enabled.
+
+Gridsite packages are available through `EGI's UMD repository
+<http://repository.egi.eu/>`_ for most distributions. Once installed, enable it
+in your Apache configuration with a line similar to this (be sure to check your
+distribution gridsite package for details)::
+
+    LoadModule gridsite_module /usr/lib/apache2/modules/mod_gridsite.so
+
 
 Catalog
 ~~~~~~~


### PR DESCRIPTION
Not for merging, just want to get some feedback on the feasibility of getting this or similar into the main repo.

This code relies on having gridsite available at Apache thus the GRST_* variables will be there. No changes are done to the validation of the proxy coming from user.

(now with better branch name)